### PR TITLE
Silence false positive dead code warning

### DIFF
--- a/denon-control/src/main.rs
+++ b/denon-control/src/main.rs
@@ -92,6 +92,7 @@ fn get_receiver_and_port(
 }
 
 #[derive(Debug)]
+#[allow(dead_code)] // Fields will be used when an error is printed
 enum Error {
     Send(std::sync::mpsc::SendError<(Operation, State)>),
     ParseInt(std::num::ParseIntError),


### PR DESCRIPTION
Members wil be used when an error occurs and is printed to console.