### PR TITLE
Faster and more robust read() function

### DIFF
--- a/denon-control/src/avahi3.rs
+++ b/denon-control/src/avahi3.rs
@@ -7,7 +7,7 @@ use zeroconf::txt_record::TTxtRecord;
 use zeroconf::{MdnsBrowser, ServiceDiscovery, ServiceType};
 
 #[derive(Default, Debug)]
-pub struct Context {
+struct Context {
     service_discovery: Option<ServiceDiscovery>,
 }
 
@@ -58,8 +58,12 @@ fn on_service_discovered(
     }
 }
 
+fn get_roap_service_type() -> ServiceType {
+    ServiceType::new("raop", "tcp").unwrap()
+}
+
 pub fn get_receiver() -> Result<String, Error> {
-    let sd = get_hostname(ServiceType::new("raop", "tcp").unwrap())?;
+    let sd = get_hostname(get_roap_service_type())?;
     if let Some(txt) = sd.txt() {
         for (_type, value) in txt.iter() {
             if value.contains("DENON") {
@@ -72,7 +76,7 @@ pub fn get_receiver() -> Result<String, Error> {
 
 #[cfg(test)]
 mod test {
-    use super::get_receiver;
+    use super::{get_receiver, get_roap_service_type};
     use crate::{avahi3::get_hostname, avahi_error::Error};
     use std::net::TcpStream;
     use zeroconf::ServiceType;
@@ -93,8 +97,7 @@ mod test {
 
     #[test]
     fn get_hostname_returns() {
-        let sn = ServiceType::new("raop", "tcp").unwrap();
-        match get_hostname(sn) {
+        match get_hostname(get_roap_service_type()) {
             Ok(address) => {
                 let stream = TcpStream::connect((address.host_name().clone(), *address.port()));
                 println!(

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -285,4 +285,24 @@ pub mod test {
         // TODO test still does not work, should print error
         Ok(())
     }
+
+    #[test]
+    fn read_without_valid_content_returns_empty_vec() -> Result<(), io::Error> {
+        let listen_socket = TcpListener::bind("127.0.0.1:0")?;
+        let addr = listen_socket.local_addr()?;
+        let mut client = TcpStream::connect(addr)?;
+        let (mut to_client, _) = listen_socket.accept()?;
+
+        // as \r is missing, read() does not read or extract anything
+        write(&mut to_client, "blub".to_string())?;
+        let lines = read(&mut client, 1)?;
+        assert_eq!(lines, Vec::<String>::new());
+
+        // read() reads until \r and leaves other data in the stream
+        write(&mut to_client, "bla\rfoo".to_string())?;
+        let lines = read(&mut client, 2)?;
+        assert_eq!(lines, vec!["blubbla".to_owned()]);
+
+        Ok(())
+    }
 }

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -82,7 +82,7 @@ fn thread_func_impl(
             write(&mut stream, command)?;
         }
 
-        match read(&mut stream, 1) {
+        match read(&stream, 1) {
             Ok(status_update) => {
                 let parsed_response = parse_response(&status_update);
                 let mut locked_state = state.lock().unwrap();


### PR DESCRIPTION
Now read() only returns a Vec with non empty strings and need no special handling for blocking or non blocking sockets