### PR TITLE
Seperate threads only reads response from receiver

### DIFF
--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -23,7 +23,13 @@ pub fn read(mut stream: &TcpStream, lines: u8) -> Result<Vec<String>, std::io::E
     while (lines as usize) != result.len() {
         let mut buffer = [0; 100];
         let read_bytes;
-        match stream.peek(&mut buffer) {
+        let pr = stream.peek(&mut buffer);
+        println!(
+            "peek result == {:?}, buffer == {:?}",
+            pr,
+            std::str::from_utf8(&buffer)
+        );
+        match pr {
             Ok(rb) => read_bytes = rb,
             Err(e) => {
                 if result.is_empty() {
@@ -84,6 +90,7 @@ fn thread_func_impl(
 
         match read(&stream, 1) {
             Ok(status_update) => {
+                println!("read() returned {:?}", status_update);
                 let parsed_response = parse_response(&status_update);
                 let mut locked_state = state.lock().unwrap();
                 for item in parsed_response {
@@ -92,9 +99,11 @@ fn thread_func_impl(
             }
             // check for timeout error -> continue on timeout error, else abort
             Err(e) => {
+                println!("read() returned {:?}", e);
                 if std::io::ErrorKind::TimedOut != e.kind()
                     && std::io::ErrorKind::WouldBlock != e.kind()
                 {
+                    println!("thread terminate");
                     return Err(e);
                 }
             }

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -25,7 +25,8 @@ pub fn read(mut stream: &TcpStream, lines: u8) -> Result<Vec<String>, std::io::E
         let read_bytes;
         let pr = stream.peek(&mut buffer);
         println!(
-            "peek result == {:?}, buffer == {:?}",
+            "lines == {}, peek result == {:?}, buffer == {:?}",
+            lines,
             pr,
             std::str::from_utf8(&buffer)
         );

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -204,10 +204,7 @@ pub mod test {
         Ok((to_denon_client, dc))
     }
 
-    fn compare_with_io_error(
-        left: Result<State, io::Error>,
-        right: Result<State, io::Error>,
-    ) -> bool {
+    fn cmp(left: Result<State, io::Error>, right: Result<State, io::Error>) -> bool {
         if left.is_ok() && right.is_ok() {
             return left.unwrap() == right.unwrap();
         }
@@ -231,7 +228,7 @@ pub mod test {
         let rc = dc.get(State::main_volume());
         let query = read(&mut to_denon_client, 1)?;
         let x: Result<State, io::Error> = Ok(State::Unknown);
-        assert!(compare_with_io_error(rc, x));
+        assert!(cmp(rc, x));
         assert_eq!(query, vec!["MV?"]);
         Ok(())
     }
@@ -259,28 +256,19 @@ pub mod test {
     #[test]
     fn connection_receives_multiple_values_volume_from_receiver() -> Result<(), io::Error> {
         let (mut to_denon_client, mut dc) = create_connected_connection()?;
-        assert!(compare_with_io_error(
-            Ok(State::Unknown),
-            dc.get(State::main_volume())
-        ));
-        assert!(compare_with_io_error(
-            Ok(State::Unknown),
-            dc.get(State::source_input())
-        ));
-        assert!(compare_with_io_error(
-            Ok(State::Unknown),
-            dc.get(State::power())
-        ));
+        assert!(cmp(Ok(State::Unknown), dc.get(State::main_volume())));
+        assert!(cmp(Ok(State::Unknown), dc.get(State::source_input())));
+        assert!(cmp(Ok(State::Unknown), dc.get(State::power())));
         write(&mut to_denon_client, "MV234\rSICD\rPWON\r".to_string())?;
-        assert!(compare_with_io_error(
+        assert!(cmp(
             Ok(State::MainVolume(234)),
             dc.get(State::main_volume())
         ));
-        assert!(compare_with_io_error(
+        assert!(cmp(
             Ok(State::SourceInput(SourceInputState::Cd)),
             dc.get(State::source_input())
         ));
-        assert!(compare_with_io_error(
+        assert!(cmp(
             Ok(State::Power(PowerState::On)),
             dc.get(State::power())
         ));
@@ -293,12 +281,12 @@ pub mod test {
         write(&mut to_denon_client, "MV234\r".to_string())?;
         assert_eq!(
             State::MainVolume(234),
-            dc.get(State::MainVolume(666)).unwrap()
+            dc.get(State::main_volume()).unwrap()
         );
         write(&mut to_denon_client, "MV320\r".to_string())?;
         assert_eq!(
             State::MainVolume(234),
-            dc.get(State::MainVolume(666)).unwrap()
+            dc.get(State::main_volume()).unwrap()
         );
         Ok(())
     }

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -112,14 +112,12 @@ impl DenonConnection {
 
         let s = TcpStream::connect((denon_name.as_str(), denon_port))?;
 
-        let read_timeout = Some(Duration::from_millis(10000));
+        let read_timeout = None;
         s.set_read_timeout(read_timeout)?;
         s.set_nonblocking(false)?;
         assert_eq!(read_timeout, s.read_timeout().unwrap());
 
         let s2 = s.try_clone()?;
-
-        assert_eq!(read_timeout, s2.read_timeout().unwrap());
 
         let threadhandle = thread::spawn(move || thread_func_impl(&s2, cloned_state));
 

--- a/denon-control/src/operation.rs
+++ b/denon-control/src/operation.rs
@@ -2,5 +2,4 @@
 pub enum Operation {
     Query,
     Set,
-    Stop,
 }


### PR DESCRIPTION
This simplifies IO as read() can now block until data has been received. In addition to that the read thread only needs to send data to the main thread and not receive any commands anymore.