### PR TITLE
Check values of enum variants in test

### DIFF
--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -257,7 +257,7 @@ pub mod test {
     }
 
     #[test]
-    fn connection_keeps_first_after_second_receive() -> Result<(), io::Error> {
+    fn connection_updates_values_with_newly_received_data() -> Result<(), io::Error> {
         let (mut to_denon_client, mut dc) = create_connected_connection()?;
         write_string(&mut to_denon_client, "MV234\r".to_string())?;
         assert_eq!(
@@ -266,7 +266,7 @@ pub mod test {
         );
         write_string(&mut to_denon_client, "MV320\r".to_string())?;
         assert_eq!(
-            State::MainVolume(234),
+            State::MainVolume(320),
             dc.get(State::main_volume()).unwrap()
         );
         Ok(())

--- a/denon-control/src/state.rs
+++ b/denon-control/src/state.rs
@@ -219,6 +219,7 @@ mod test {
 
     #[test]
     fn state_equal_main_volume() {
+        // TODO maybe this behavior is not the best one. == should also compare the stored integer
         assert_eq!(State::MainVolume(12), State::MainVolume(23));
         assert_ne!(State::MainVolume(12), State::MaxVolume(23));
         assert_ne!(State::MainVolume(12), State::MaxVolume(12));

--- a/denon-control/src/state.rs
+++ b/denon-control/src/state.rs
@@ -219,7 +219,6 @@ mod test {
 
     #[test]
     fn state_equal_main_volume() {
-        // TODO maybe this behavior is not the best one. == should also compare the stored integer
         assert_eq!(State::MainVolume(12), State::MainVolume(23));
         assert_ne!(State::MainVolume(12), State::MaxVolume(23));
         assert_ne!(State::MainVolume(12), State::MaxVolume(12));


### PR DESCRIPTION
For using a HashSet as a database the values of each enum variant are ignored. Thus each enum variant has a stable hash value, which is not changed by the stored value. This allows updating old data with new data in the HashSet, but it non obvious behavior in other cases, like checking the enum variant with value. Thus tests have been adapted until a better design is found.