### PR TITLE
Use HashMap for storing state

### DIFF
--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -167,22 +167,9 @@ impl DenonConnection {
         self.to_receiver.shutdown(std::net::Shutdown::Both)
     }
 
-    pub fn set(&mut self, state: SetState) -> Result<(), io::Error> {
-        match state {
-            SetState::MainVolume(i) => {
-                self.query(State::MainVolume, StateValue::Integer(i), Operation::Set)
-            }
-
-            SetState::MaxVolume(i) => {
-                self.query(State::MaxVolume, StateValue::Integer(i), Operation::Set)
-            }
-            SetState::Power(ps) => self.query(State::Power, StateValue::Power(ps), Operation::Set),
-            SetState::SourceInput(si) => self.query(
-                State::SourceInput,
-                StateValue::SourceInput(si),
-                Operation::Set,
-            ),
-        }
+    pub fn set(&mut self, sstate: SetState) -> Result<(), io::Error> {
+        let (state, state_value) = sstate.convert();
+        self.query(state, state_value, Operation::Set)
     }
 }
 

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -91,7 +91,8 @@ fn thread_func_impl(
             Ok(status_update) => {
                 let parsed_response = parse_response(&status_update);
                 let mut locked_state = state.lock().unwrap();
-                for (state, value) in parsed_response {
+                for sstate in parsed_response {
+                    let (state, value) = sstate.convert();
                     locked_state.insert(state, value);
                 }
             }
@@ -110,7 +111,7 @@ fn thread_func_impl(
     }
 }
 
-fn parse_response(response: &[String]) -> Vec<(State, StateValue)> {
+fn parse_response(response: &[String]) -> Vec<SetState> {
     return response.iter().filter_map(|x| parse(x.as_str())).collect();
 }
 

--- a/denon-control/src/main.rs
+++ b/denon-control/src/main.rs
@@ -11,9 +11,7 @@ mod parse;
 mod state;
 
 use denon_connection::{DenonConnection, State};
-use state::PowerState;
-use state::SourceInputState;
-use state::StateValue;
+use state::{PowerState, SetState, SourceInputState};
 
 use getopts::Options;
 use std::env;
@@ -128,7 +126,7 @@ fn main2(args: getopts::Matches, denon_name: String, denon_port: u16) -> Result<
     if let Some(p) = args.opt_str("p") {
         for power in PowerState::iterator() {
             if power.to_string() == p {
-                dc.set(State::Power, StateValue::Power(*power))?;
+                dc.set(SetState::Power(*power))?;
             }
         }
     }
@@ -136,7 +134,7 @@ fn main2(args: getopts::Matches, denon_name: String, denon_port: u16) -> Result<
     if let Some(i) = args.opt_str("i") {
         for input in SourceInputState::iterator() {
             if input.to_string() == i {
-                dc.set(State::SourceInput, StateValue::SourceInput(*input))?;
+                dc.set(SetState::SourceInput(*input))?;
             }
         }
     }
@@ -147,7 +145,7 @@ fn main2(args: getopts::Matches, denon_name: String, denon_port: u16) -> Result<
         if vi > 50 {
             vi = 50;
         }
-        dc.set(State::MainVolume, StateValue::Integer(vi))?;
+        dc.set(SetState::MainVolume(vi))?;
     }
     Ok(())
 }

--- a/denon-control/src/parse.rs
+++ b/denon-control/src/parse.rs
@@ -2,13 +2,14 @@ pub use crate::operation::Operation;
 pub use crate::state::PowerState;
 pub use crate::state::SourceInputState;
 pub use crate::state::State;
+use crate::state::StateValue;
 
 macro_rules! parsehelper {
     ($trimmed:expr, $op:expr, $func:path) => {
         if $trimmed.starts_with($op.value()) {
             let value = get_value($trimmed, &$op);
             let x = $func(value);
-            return Some(x);
+            return Some(($op, x));
         }
     };
 }
@@ -26,47 +27,50 @@ fn parse_int(to_parse: &str) -> u32 {
     value
 }
 
-fn parse_main_volume(value: &str) -> State {
+fn parse_main_volume(value: &str) -> StateValue {
     let value = parse_int(value);
-    State::MainVolume(value)
+    StateValue::Integer(value)
 }
 
-fn parse_max_volume(value: &str) -> State {
+fn parse_max_volume(value: &str) -> StateValue {
     let value = parse_int(value);
-    State::MaxVolume(value)
+    StateValue::Integer(value)
 }
 
-fn parse_power(value: &str) -> State {
+fn parse_power(value: &str) -> StateValue {
     if "ON" == value {
-        State::Power(PowerState::On)
+        StateValue::Power(PowerState::On)
     } else {
-        State::Power(PowerState::Standby)
+        StateValue::Power(PowerState::Standby)
     }
 }
 
-fn parse_source_input(value: &str) -> State {
+fn parse_source_input(value: &str) -> StateValue {
     for sis in SourceInputState::iterator() {
         if sis.to_string() == value {
-            return State::SourceInput(sis.clone());
+            return StateValue::SourceInput(*sis);
         }
     }
 
-    State::SourceInput(SourceInputState::Unknown)
+    StateValue::SourceInput(SourceInputState::Unknown)
 }
 
-pub fn parse(str: &str) -> Option<State> {
+pub fn parse(str: &str) -> Option<(State, StateValue)> {
     let trimmed = str.trim().trim_matches('\r');
-    parsehelper!(trimmed, State::max_volume(), parse_max_volume);
-    parsehelper!(trimmed, State::main_volume(), parse_main_volume);
-    parsehelper!(trimmed, State::power(), parse_power);
-    parsehelper!(trimmed, State::source_input(), parse_source_input);
+    parsehelper!(trimmed, State::MaxVolume, parse_max_volume);
+    parsehelper!(trimmed, State::MainVolume, parse_main_volume);
+    parsehelper!(trimmed, State::Power, parse_power);
+    parsehelper!(trimmed, State::SourceInput, parse_source_input);
     None
 }
 
 #[cfg(test)]
 mod test {
     use super::parse;
-    use crate::parse::{PowerState, SourceInputState, State};
+    use crate::{
+        parse::{PowerState, SourceInputState, State},
+        state::StateValue,
+    };
 
     #[test]
     fn parse_with_unknown_string() {
@@ -82,58 +86,51 @@ mod test {
 
     #[test]
     fn max_volume() {
-        assert!(matches!(parse("MVMAX0"), Some(State::MaxVolume(0))));
-        assert!(matches!(parse("MVMAX23"), Some(State::MaxVolume(230))));
-        assert!(matches!(parse("MVMAX99"), Some(State::MaxVolume(990))));
-        assert!(matches!(parse("MVMAX100"), Some(State::MaxVolume(100))));
-        assert!(matches!(parse("MVMAX230"), Some(State::MaxVolume(230))));
-        assert!(matches!(parse("MVMAX999"), Some(State::MaxVolume(999))));
-        assert!(matches!(parse("MVMAX 999"), Some(State::MaxVolume(999))));
+        let create = |i| Some((State::MaxVolume, StateValue::Integer(i)));
+
+        assert_eq!(parse("MVMAX0"), create(0));
+        assert_eq!(parse("MVMAX23"), create(230));
+        assert_eq!(parse("MVMAX99"), create(990));
+        assert_eq!(parse("MVMAX100"), create(100));
+        assert_eq!(parse("MVMAX230"), create(230));
+        assert_eq!(parse("MVMAX999"), create(999));
+        assert_eq!(parse("MVMAX 999"), create(999));
     }
 
     #[test]
     #[should_panic]
-    fn main_voule_without_value_panics() {
+    fn main_volume_without_value_panics() {
         parse("MV");
     }
 
     #[test]
-    fn main_voule() {
-        assert!(matches!(parse("MV 0"), Some(State::MainVolume(0))));
-        assert!(matches!(parse("MV 23"), Some(State::MainVolume(230))));
-        assert!(matches!(parse("MV 99"), Some(State::MainVolume(990))));
-        assert!(matches!(parse("MV 100"), Some(State::MainVolume(100))));
-        assert!(matches!(parse("MV 230"), Some(State::MainVolume(230))));
-        assert!(matches!(parse("MV 999"), Some(State::MainVolume(999))));
-        assert!(matches!(parse("MV999"), Some(State::MainVolume(999))));
+    fn main_volume() {
+        let create = |i| Some((State::MainVolume, StateValue::Integer(i)));
+
+        assert_eq!(parse("MV 0"), create(0));
+        assert_eq!(parse("MV 23"), create(230));
+        assert_eq!(parse("MV 99"), create(990));
+        assert_eq!(parse("MV 100"), create(100));
+        assert_eq!(parse("MV 230"), create(230));
+        assert_eq!(parse("MV 999"), create(999));
+        assert_eq!(parse("MV999"), create(999));
     }
 
     #[test]
     fn power() {
-        assert!(matches!(
-            parse("PW"),
-            Some(State::Power(PowerState::Standby))
-        ));
-        assert!(matches!(
-            parse("PWOFF"),
-            Some(State::Power(PowerState::Standby))
-        ));
-        assert!(matches!(parse("PWON"), Some(State::Power(PowerState::On))));
+        let create = |ps| Some((State::Power, StateValue::Power(ps)));
+
+        assert_eq!(parse("PW"), create(PowerState::Standby));
+        assert_eq!(parse("PWOFF"), create(PowerState::Standby));
+        assert_eq!(parse("PWON"), create(PowerState::On));
     }
 
     #[test]
     fn source_input() {
-        assert!(matches!(
-            parse("SI"),
-            Some(State::SourceInput(SourceInputState::Unknown))
-        ));
-        assert!(matches!(
-            parse("SIblub"),
-            Some(State::SourceInput(SourceInputState::Unknown))
-        ));
-        assert!(matches!(
-            parse("SITV"),
-            Some(State::SourceInput(SourceInputState::Tv))
-        ));
+        let create = |si| Some((State::SourceInput, StateValue::SourceInput(si)));
+
+        assert_eq!(parse("SI"), create(SourceInputState::Unknown));
+        assert_eq!(parse("SIblub"), create(SourceInputState::Unknown));
+        assert_eq!(parse("SITV"), create(SourceInputState::Tv));
     }
 }

--- a/denon-control/src/parse.rs
+++ b/denon-control/src/parse.rs
@@ -19,21 +19,11 @@ fn get_value<'a>(trimmed: &'a str, op: &State) -> &'a str {
     trimmed[to_skip..].trim()
 }
 
-fn parse_int(to_parse: &str) -> u32 {
+fn parse_int(to_parse: &str) -> StateValue {
     let mut value = to_parse.parse::<u32>().unwrap();
     if value < 100 {
         value *= 10;
     }
-    value
-}
-
-fn parse_main_volume(value: &str) -> StateValue {
-    let value = parse_int(value);
-    StateValue::Integer(value)
-}
-
-fn parse_max_volume(value: &str) -> StateValue {
-    let value = parse_int(value);
     StateValue::Integer(value)
 }
 
@@ -57,8 +47,8 @@ fn parse_source_input(value: &str) -> StateValue {
 
 pub fn parse(str: &str) -> Option<(State, StateValue)> {
     let trimmed = str.trim().trim_matches('\r');
-    parsehelper!(trimmed, State::MaxVolume, parse_max_volume);
-    parsehelper!(trimmed, State::MainVolume, parse_main_volume);
+    parsehelper!(trimmed, State::MaxVolume, parse_int);
+    parsehelper!(trimmed, State::MainVolume, parse_int);
     parsehelper!(trimmed, State::Power, parse_power);
     parsehelper!(trimmed, State::SourceInput, parse_source_input);
     None

--- a/denon-control/src/state.rs
+++ b/denon-control/src/state.rs
@@ -124,6 +124,14 @@ impl Display for State {
     }
 }
 
+#[allow(dead_code)] // currently MaxVolume is not used, but supported
+pub enum SetState {
+    Power(PowerState),
+    SourceInput(SourceInputState),
+    MaxVolume(u32),
+    MainVolume(u32),
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum StateValue {
     Power(PowerState),

--- a/denon-control/src/state.rs
+++ b/denon-control/src/state.rs
@@ -241,5 +241,6 @@ mod test {
                 StateValue::SourceInput(SourceInputState::Dvd)
             )
         );
+        assert_eq!("PW", ts(State::Power, StateValue::Unknown));
     }
 }

--- a/denon-control/src/state.rs
+++ b/denon-control/src/state.rs
@@ -125,6 +125,7 @@ impl Display for State {
 }
 
 #[allow(dead_code)] // currently MaxVolume is not used, but supported
+#[derive(Debug, PartialEq)]
 pub enum SetState {
     Power(PowerState),
     SourceInput(SourceInputState),

--- a/denon-control/src/state.rs
+++ b/denon-control/src/state.rs
@@ -132,6 +132,17 @@ pub enum SetState {
     MainVolume(u32),
 }
 
+impl SetState {
+    pub fn convert(&self) -> (State, StateValue) {
+        match *self {
+            SetState::MainVolume(i) => (State::MainVolume, StateValue::Integer(i)),
+            SetState::MaxVolume(i) => (State::MaxVolume, StateValue::Integer(i)),
+            SetState::Power(ps) => (State::Power, StateValue::Power(ps)),
+            SetState::SourceInput(si) => (State::SourceInput, StateValue::SourceInput(si)),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum StateValue {
     Power(PowerState),

--- a/denon-control/src/state.rs
+++ b/denon-control/src/state.rs
@@ -1,9 +1,9 @@
 use std::cmp::{Eq, PartialEq};
 use std::fmt::{Display, Error, Formatter, Write};
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::slice::Iter;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PowerState {
     On,
     Standby,
@@ -24,7 +24,7 @@ impl PowerState {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SourceInputState {
     Cd,
     Tuner,
@@ -99,242 +99,97 @@ impl SourceInputState {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum State {
-    Power(PowerState),
-    SourceInput(SourceInputState),
-    MaxVolume(u32),
-    MainVolume(u32),
-    Unknown,
+    Power,
+    SourceInput,
+    MaxVolume,
+    MainVolume,
 }
 
 impl State {
     pub fn value(&self) -> &'static str {
         match *self {
-            State::Power(_) => "PW",
-            State::SourceInput(_) => "SI",
-            State::MaxVolume(_) => "MVMAX",
-            State::MainVolume(_) => "MV",
-            State::Unknown => "Unknown",
+            State::Power => "PW",
+            State::SourceInput => "SI",
+            State::MaxVolume => "MVMAX",
+            State::MainVolume => "MV",
         }
-    }
-
-    pub fn power() -> State {
-        State::Power(PowerState::On)
-    }
-
-    pub fn source_input() -> State {
-        State::SourceInput(SourceInputState::Dvd)
-    }
-
-    pub fn max_volume() -> State {
-        State::MaxVolume(0)
-    }
-
-    pub fn main_volume() -> State {
-        State::MainVolume(0)
     }
 }
 
 impl Display for State {
     fn fmt(&self, format: &mut Formatter) -> Result<(), Error> {
+        write!(format, "{}", self.value())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StateValue {
+    Power(PowerState),
+    SourceInput(SourceInputState),
+    Integer(u32),
+    Unknown,
+}
+
+impl Display for StateValue {
+    fn fmt(&self, format: &mut Formatter) -> Result<(), Error> {
         match *self {
-            State::Power(ref p) => write!(format, "{}{}", self.value(), p),
-            State::SourceInput(ref si) => write!(format, "{}{}", self.value(), si),
-            State::MaxVolume(i) => write!(format, "{}{}", self.value(), i),
-            State::MainVolume(i) => write!(format, "{}{}", self.value(), i),
-            State::Unknown => write!(format, "{}", self.value()),
+            StateValue::Power(ref p) => write!(format, "{}", p),
+            StateValue::SourceInput(ref si) => write!(format, "{}", si),
+            StateValue::Integer(i) => write!(format, "{}", i),
+            StateValue::Unknown => Ok(()),
         }
     }
 }
-
-impl Hash for State {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match *self {
-            State::Power(_) => 1.hash(state),
-            State::SourceInput(_) => 2.hash(state),
-            State::MaxVolume(_) => 3.hash(state),
-            State::MainVolume(_) => 4.hash(state),
-            State::Unknown => 5.hash(state),
-        }
-    }
-}
-
-macro_rules! equal_helper {
-    ($first:ident, $second:ident, $enum_value:path) => {
-        if matches!(*$first, $enum_value(_)) && matches!(*$second, $enum_value(_)) {
-            return true;
-        }
-    };
-}
-
-impl PartialEq for State {
-    fn eq(&self, other: &State) -> bool {
-        equal_helper!(self, other, State::Power);
-        equal_helper!(self, other, State::SourceInput);
-        equal_helper!(self, other, State::MaxVolume);
-        equal_helper!(self, other, State::MainVolume);
-        matches!(self, State::Unknown) && matches!(other, State::Unknown)
-    }
-}
-
-impl Eq for State {}
 
 #[cfg(test)]
 mod test {
+    use super::StateValue;
     use crate::state::{PowerState, SourceInputState, State};
-    use std::collections::HashSet;
+    use std::collections::HashMap;
 
-    fn check_value(hs: &HashSet<State>, expected: &State) {
-        match expected {
-            State::MainVolume(v) => {
-                let get_value = State::MainVolume(v + 1);
-                let value = hs.get(&get_value).unwrap();
-                assert!(matches!(value, State::MainVolume(vv) if vv == v));
-            }
-            State::MaxVolume(v) => {
-                let get_value = State::MaxVolume(v + 1);
-                let value = hs.get(&get_value).unwrap();
-                assert!(matches!(value, State::MaxVolume(vv) if vv == v));
-            }
-            State::Power(p) => {
-                let get_value = match p {
-                    PowerState::On => State::Power(PowerState::Standby),
-                    PowerState::Standby => State::Power(PowerState::On),
-                };
-                let value = hs.get(&get_value).unwrap();
-                assert!(matches!(value, State::Power(vv) if vv == p));
-            }
-            State::SourceInput(si) => {
-                let get_value = State::SourceInput(SourceInputState::Ipd);
-                let value = hs.get(&get_value).unwrap();
-                assert!(matches!(value, State::SourceInput(vv) if vv == si));
-            }
-            State::Unknown => {
-                let value = hs.get(&State::Unknown).unwrap();
-                assert!(matches!(value, State::Unknown));
-            }
-        }
+    fn check_value(hs: &HashMap<State, StateValue>, key: &State, expected_value: &StateValue) {
+        let value = hs.get(key).unwrap();
+        assert!(matches!(value, value if value == expected_value));
     }
 
     #[test]
-    fn state_equal_main_volume() {
-        assert_eq!(State::MainVolume(12), State::MainVolume(23));
-        assert_ne!(State::MainVolume(12), State::MaxVolume(23));
-        assert_ne!(State::MainVolume(12), State::MaxVolume(12));
-        assert_ne!(State::MainVolume(12), State::Power(PowerState::On));
-        assert_ne!(
-            State::MainVolume(12),
-            State::SourceInput(SourceInputState::Bd)
-        );
-        assert_ne!(State::MainVolume(12), State::Unknown);
-    }
+    fn state_works_in_map() {
+        let mut hm = HashMap::new();
+        let mv = State::MainVolume;
+        let i100 = StateValue::Integer(100);
+        hm.insert(mv, i100);
+        assert_eq!(1, hm.len());
+        check_value(&hm, &mv, &i100);
 
-    #[test]
-    fn state_equal_max_volume() {
-        assert_eq!(State::MaxVolume(12), State::MaxVolume(23));
-        assert_ne!(State::MaxVolume(12), State::MainVolume(23));
-        assert_ne!(State::MaxVolume(12), State::MainVolume(12));
-        assert_ne!(State::MaxVolume(12), State::Power(PowerState::On));
-        assert_ne!(
-            State::MaxVolume(12),
-            State::SourceInput(SourceInputState::Bd)
-        );
-        assert_ne!(State::MaxVolume(12), State::Unknown);
-    }
+        let i129 = StateValue::Integer(129);
+        hm.insert(mv, i129);
+        assert_eq!(1, hm.len());
+        check_value(&hm, &mv, &i129);
 
-    #[test]
-    fn state_equal_power() {
-        assert_eq!(State::Power(PowerState::On), State::Power(PowerState::On));
-        assert_eq!(
-            State::Power(PowerState::On),
-            State::Power(PowerState::Standby)
-        );
-        assert_ne!(State::Power(PowerState::On), State::MainVolume(23));
-        assert_ne!(State::Power(PowerState::On), State::MaxVolume(12));
-        assert_ne!(
-            State::Power(PowerState::On),
-            State::SourceInput(SourceInputState::Bd)
-        );
-        assert_ne!(State::Power(PowerState::On), State::Unknown);
-    }
+        let maxv = State::MaxVolume;
+        hm.insert(maxv, i100);
+        assert_eq!(2, hm.len());
+        check_value(&hm, &mv, &i129);
+        check_value(&hm, &maxv, &i100);
 
-    #[test]
-    fn state_equal_source_input() {
-        assert_eq!(
-            State::SourceInput(SourceInputState::Bd),
-            State::SourceInput(SourceInputState::Cd)
-        );
-        assert_eq!(
-            State::SourceInput(SourceInputState::Bd),
-            State::SourceInput(SourceInputState::Fvp)
-        );
-        assert_ne!(
-            State::SourceInput(SourceInputState::Bd),
-            State::MainVolume(23)
-        );
-        assert_ne!(
-            State::SourceInput(SourceInputState::Bd),
-            State::MaxVolume(12)
-        );
-        assert_ne!(
-            State::SourceInput(SourceInputState::Bd),
-            State::Power(PowerState::On)
-        );
-        assert_ne!(State::SourceInput(SourceInputState::Bd), State::Unknown);
-    }
+        let power = State::Power;
+        let pon = StateValue::Power(PowerState::On);
+        hm.insert(power, pon);
+        assert_eq!(3, hm.len());
+        check_value(&hm, &mv, &i129);
+        check_value(&hm, &maxv, &i100);
+        check_value(&hm, &power, &pon);
 
-    #[test]
-    fn state_equal_unknown() {
-        assert_eq!(State::Unknown, State::Unknown);
-        assert_ne!(State::Unknown, State::MainVolume(23));
-        assert_ne!(State::Unknown, State::MaxVolume(12));
-        assert_ne!(State::Unknown, State::SourceInput(SourceInputState::Bd));
-        assert_ne!(State::Unknown, State::SourceInput(SourceInputState::Bd));
-    }
-
-    #[test]
-    fn state_works_in_set() {
-        let mut hs = HashSet::new();
-        let mv_100 = State::MainVolume(100);
-        hs.replace(mv_100.clone());
-        assert_eq!(1, hs.len());
-        check_value(&hs, &mv_100);
-
-        let mv_129 = State::MainVolume(129);
-        hs.replace(mv_129.clone());
-        assert_eq!(1, hs.len());
-        check_value(&hs, &mv_129);
-
-        let maxv_100 = State::MaxVolume(100);
-        hs.replace(maxv_100.clone());
-        assert_eq!(2, hs.len());
-        check_value(&hs, &mv_129);
-        check_value(&hs, &maxv_100);
-
-        let power_on = State::Power(PowerState::On);
-        hs.replace(power_on.clone());
-        assert_eq!(3, hs.len());
-        check_value(&hs, &mv_129);
-        check_value(&hs, &maxv_100);
-        check_value(&hs, &power_on);
-
-        let sibd = State::SourceInput(SourceInputState::Bd);
-        hs.replace(sibd.clone());
-        assert_eq!(4, hs.len());
-        check_value(&hs, &mv_129);
-        check_value(&hs, &maxv_100);
-        check_value(&hs, &power_on);
-        check_value(&hs, &sibd);
-
-        let unkown = State::Unknown;
-        hs.replace(unkown.clone());
-        assert_eq!(5, hs.len());
-        check_value(&hs, &mv_129);
-        check_value(&hs, &maxv_100);
-        check_value(&hs, &power_on);
-        check_value(&hs, &sibd);
-        check_value(&hs, &unkown);
+        let si = State::SourceInput;
+        let sibd = StateValue::SourceInput(SourceInputState::Bd);
+        hm.insert(si, sibd);
+        assert_eq!(4, hm.len());
+        check_value(&hm, &mv, &i129);
+        check_value(&hm, &maxv, &i100);
+        check_value(&hm, &power, &pon);
+        check_value(&hm, &si, &sibd);
     }
 
     #[test]
@@ -359,13 +214,24 @@ mod test {
 
     #[test]
     fn state_display() {
-        assert_eq!("MV23", State::MainVolume(23).to_string());
-        assert_eq!("MVMAX230", State::MaxVolume(230).to_string());
-        assert_eq!("PWON", State::Power(PowerState::On).to_string());
+        assert_eq!("MV", State::MainVolume.to_string());
+        assert_eq!("MVMAX", State::MaxVolume.to_string());
+        assert_eq!("PW", State::Power.to_string());
+        assert_eq!("SI", State::SourceInput.to_string());
+    }
+
+    #[test]
+    fn state_statevalue_display() {
+        let ts = |s, sv| format!("{}{}", s, sv);
+        assert_eq!("MV230", ts(State::MainVolume, StateValue::Integer(230)));
+        assert_eq!("MVMAX666", ts(State::MaxVolume, StateValue::Integer(666)));
+        assert_eq!("PWON", ts(State::Power, StateValue::Power(PowerState::On)));
         assert_eq!(
-            "SIDOCK",
-            State::SourceInput(SourceInputState::Dock).to_string()
+            "SIDVD",
+            ts(
+                State::SourceInput,
+                StateValue::SourceInput(SourceInputState::Dvd)
+            )
         );
-        assert_eq!("Unknown", State::Unknown.to_string());
     }
 }


### PR DESCRIPTION
Implementing the hash function in a strange way required that the equality operator acted the same way. Now lets see what makes more sense.

The old design made it impossible to use the API wrong, which is now possible, but types behave now more idiomatic.