### PR TITLE
Cover line in main2() and reduce complexity of write() function

### DIFF
--- a/denon-control/src/main.rs
+++ b/denon-control/src/main.rs
@@ -336,7 +336,7 @@ mod test {
             "localhost",
             "-s",
             "-p",
-            "OFF",
+            "STANDBY",
             "-i",
             "CD",
             "-v",
@@ -371,6 +371,11 @@ mod test {
             "{}{}",
             State::MainVolume,
             StateValue::Integer(50)
+        )));
+        assert!(received_data.contains(&format!(
+            "{}{}",
+            State::Power,
+            StateValue::Power(PowerState::Standby)
         )));
         Ok(())
     }

--- a/denon-control/src/main.rs
+++ b/denon-control/src/main.rs
@@ -6,7 +6,6 @@ mod avahi;
 mod avahi3;
 mod avahi_error;
 mod denon_connection;
-mod operation;
 mod parse;
 mod state;
 
@@ -163,11 +162,10 @@ mod test {
     use crate::avahi3;
     use crate::avahi_error;
     use crate::denon_connection::read;
-    use crate::denon_connection::write;
+    use crate::denon_connection::write_state;
     use crate::get_avahi_impl;
     use crate::get_receiver_and_port;
     use crate::main2;
-    use crate::operation::Operation;
     use crate::state::SetState;
     use crate::Error;
     use crate::PowerState;
@@ -175,14 +173,9 @@ mod test {
     use crate::{
         denon_connection::test::create_connected_connection, parse::State, parse_args, print_status,
     };
-    use std::io::{self, Write};
+    use std::io;
     use std::net::TcpListener;
     use std::thread;
-
-    fn write_state(stream: &mut dyn Write, input: SetState) -> Result<(), std::io::Error> {
-        let (state, state_value) = input.convert();
-        write(stream, state, state_value, Operation::Set)
-    }
 
     #[test]
     #[should_panic]

--- a/denon-control/src/main.rs
+++ b/denon-control/src/main.rs
@@ -168,7 +168,7 @@ mod test {
     use crate::get_receiver_and_port;
     use crate::main2;
     use crate::operation::Operation;
-    use crate::state::{SetState, StateValue};
+    use crate::state::SetState;
     use crate::Error;
     use crate::PowerState;
     use crate::SourceInputState;
@@ -361,22 +361,10 @@ mod test {
         main2(args, String::from("localhost"), local_port).unwrap();
 
         let received_data = acceptor.join().unwrap()?;
-        assert!(received_data.contains(&format!("{}?", State::Power.value())));
-        assert!(received_data.contains(&format!(
-            "{}{}",
-            State::SourceInput,
-            StateValue::SourceInput(SourceInputState::Cd)
-        )));
-        assert!(received_data.contains(&format!(
-            "{}{}",
-            State::MainVolume,
-            StateValue::Integer(50)
-        )));
-        assert!(received_data.contains(&format!(
-            "{}{}",
-            State::Power,
-            StateValue::Power(PowerState::Standby)
-        )));
+        assert!(received_data.contains(&format!("{}?", State::Power)));
+        assert!(received_data.contains(&format!("{}", SetState::SourceInput(SourceInputState::Cd))));
+        assert!(received_data.contains(&format!("{}", SetState::MainVolume(50))));
+        assert!(received_data.contains(&format!("{}", SetState::Power(PowerState::Standby))));
         Ok(())
     }
 

--- a/denon-control/src/operation.rs
+++ b/denon-control/src/operation.rs
@@ -1,5 +1,0 @@
-#[derive(PartialEq, Eq)]
-pub enum Operation {
-    Query,
-    Set,
-}

--- a/denon-control/src/parse.rs
+++ b/denon-control/src/parse.rs
@@ -1,4 +1,3 @@
-pub use crate::operation::Operation;
 pub use crate::state::PowerState;
 use crate::state::SetState;
 pub use crate::state::SourceInputState;

--- a/denon-control/src/state.rs
+++ b/denon-control/src/state.rs
@@ -144,6 +144,13 @@ impl SetState {
     }
 }
 
+impl Display for SetState {
+    fn fmt(&self, format: &mut Formatter) -> Result<(), Error> {
+        let (state, value) = self.convert();
+        write!(format, "{}{}", state, value)
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum StateValue {
     Power(PowerState),
@@ -166,7 +173,7 @@ impl Display for StateValue {
 #[cfg(test)]
 mod test {
     use super::StateValue;
-    use crate::state::{PowerState, SourceInputState, State};
+    use crate::state::{PowerState, SetState, SourceInputState, State};
     use std::collections::HashMap;
 
     fn check_value(hs: &HashMap<State, StateValue>, key: &State, expected_value: &StateValue) {
@@ -254,5 +261,16 @@ mod test {
             )
         );
         assert_eq!("PW", ts(State::Power, StateValue::Unknown));
+    }
+
+    #[test]
+    fn setstate_diplay() {
+        assert_eq!("MV230", SetState::MainVolume(230).to_string());
+        assert_eq!("MVMAX666", SetState::MaxVolume(666).to_string());
+        assert_eq!("PWON", SetState::Power(PowerState::On).to_string());
+        assert_eq!(
+            "SIDVD",
+            SetState::SourceInput(SourceInputState::Dvd).to_string()
+        );
     }
 }


### PR DESCRIPTION
Complexity came due to write() being able to do two tasks. Splitting this into separate functions reduced number of parameters needed to distinguish the tasks.