### PR TITLE
Suppress false positives from static code analysis

### DIFF
--- a/denon-control/src/avahi_error.rs
+++ b/denon-control/src/avahi_error.rs
@@ -6,7 +6,9 @@ use std::io;
 #[derive(Debug)]
 pub enum Error {
     NoHostsFound,
+    #[allow(dead_code)] // used in Display implementation
     IO(io::Error),
+    #[allow(dead_code)] // used in Display implementation
     Zeroconf(zeroconf::error::Error),
 }
 


### PR DESCRIPTION
members are used in code generated by derive macro