### PR TITLE
More tests and coverage with traits, mocks and software tests

### DIFF
--- a/denon-control/Cargo.toml
+++ b/denon-control/Cargo.toml
@@ -10,3 +10,5 @@ zeroconf = "0.15"
 
 [dev-dependencies]
 mockall = "0.13.0"
+assert_cmd = "2.0.16"
+predicates = "3.1.2"

--- a/denon-control/Cargo.toml
+++ b/denon-control/Cargo.toml
@@ -7,3 +7,6 @@ edition = '2021'
 [dependencies]
 getopts = "0.2"
 zeroconf = "0.15"
+
+[dev-dependencies]
+mockall = "0.13.0"

--- a/denon-control/src/bin/denon-control.rs
+++ b/denon-control/src/bin/denon-control.rs
@@ -1,0 +1,12 @@
+use denon_control::{
+    create_tcp_stream, get_avahi_impl, get_receiver_and_port, main2, parse_args, Error,
+};
+use std::env;
+
+fn main() -> Result<(), Error> {
+    let args = parse_args(env::args().collect());
+    let (denon_name, denon_port) = get_receiver_and_port(&args, get_avahi_impl(&args))?;
+    let s = create_tcp_stream(denon_name.as_str(), denon_port)?;
+    main2(args, s, Box::new(std::io::stdout()))?;
+    Ok(())
+}

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 const ESHUTDOWN: i32 = 108;
 
-fn write_string(stream: &mut dyn Write, input: String) -> Result<(), std::io::Error> {
+pub fn write_string(stream: &mut dyn Write, input: String) -> Result<(), std::io::Error> {
     let volume_command = input.into_bytes();
     stream.write_all(&volume_command[..])?;
     Ok(())

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -362,10 +362,7 @@ pub mod test {
 
     fn copy_string_into_slice(src: &str, dst: &mut [u8]) -> usize {
         let length = min(src.len(), dst.len());
-        let mut chars = src.chars();
-        for i in 0..length {
-            dst[i] = chars.next().unwrap() as u8;
-        }
+        dst[0..length].copy_from_slice(&src.as_bytes()[0..length]);
         length
     }
 

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -182,16 +182,17 @@ impl Drop for DenonConnection {
 
 #[cfg(test)]
 pub mod test {
-    use mockall::{mock, Sequence};
+    use mockall::Sequence;
     use predicates::ord::eq;
 
     use super::{thread_func_impl, DenonConnection};
     use crate::denon_connection::{read, write_string};
+    use crate::logger::MockLogger;
     use crate::parse::{PowerState, SourceInputState};
     use crate::state::{SetState, State, StateValue};
     use crate::stream::{create_tcp_stream, MockReadStream, MockShutdownStream};
     use std::cmp::min;
-    use std::io::{self, Error, Write};
+    use std::io::{self, Error};
     use std::net::{TcpListener, TcpStream};
     use std::sync::Arc;
     use std::thread::yield_now;
@@ -204,11 +205,6 @@ pub mod test {
         let (to_denon_client, _) = listen_socket.accept()?;
         Ok((to_denon_client, dc))
     }
-
-    mock! {Logger {} impl Write for Logger {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize>;
-        fn flush(&mut self) -> io::Result<()>;
-    }}
 
     macro_rules! wait_for_value_in_database {
         ($denon_connection:ident, $sstate:expr) => {

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -1,5 +1,4 @@
-use crate::parse::parse;
-use crate::parse::State;
+use crate::parse::{parse, State};
 use crate::state::{SetState, StateValue};
 use crate::stream::{ConnectionStream, ReadStream};
 use std::collections::HashMap;

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -199,7 +199,7 @@ pub mod test {
     pub fn create_connected_connection() -> Result<(TcpStream, DenonConnection), io::Error> {
         let listen_socket = TcpListener::bind("localhost:0")?;
         let addr = listen_socket.local_addr()?;
-        let s = create_tcp_stream(addr.ip().to_string(), addr.port())?;
+        let s = create_tcp_stream(addr.ip().to_string().as_str(), addr.port())?;
         let dc = DenonConnection::new(s, Box::new(std::io::stdout()))?;
         let (to_denon_client, _) = listen_socket.accept()?;
         Ok((to_denon_client, dc))

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -1,5 +1,5 @@
 use crate::parse::parse;
-pub use crate::parse::State;
+use crate::parse::State;
 use crate::state::{SetState, StateValue};
 use crate::stream::{ConnectionStream, ReadStream};
 use std::collections::HashMap;

--- a/denon-control/src/denon_connection.rs
+++ b/denon-control/src/denon_connection.rs
@@ -47,7 +47,7 @@ fn write_query(stream: &mut dyn Write, state: State) -> Result<(), io::Error> {
     write_string(stream, format!("{}?\r", state))
 }
 
-pub fn read(stream: &impl ReadStream, lines: u8) -> Result<Vec<String>, std::io::Error> {
+pub fn read(stream: &dyn ReadStream, lines: u8) -> Result<Vec<String>, std::io::Error> {
     let mut result = Vec::<String>::new();
 
     // guarantee to read a full line. check that read content ends with \r
@@ -98,7 +98,7 @@ pub fn read(stream: &impl ReadStream, lines: u8) -> Result<Vec<String>, std::io:
 }
 
 fn thread_func_impl(
-    stream: &impl ReadStream,
+    stream: &dyn ReadStream,
     state: Arc<Mutex<HashMap<State, StateValue>>>,
 ) -> Result<(), std::io::Error> {
     loop {

--- a/denon-control/src/lib.rs
+++ b/denon-control/src/lib.rs
@@ -14,10 +14,9 @@ mod stream;
 mod logger;
 
 use denon_connection::DenonConnection;
-pub use denon_connection::{read, write_state};
+pub use denon_connection::{read, write_string};
 use getopts::Options;
-pub use state::State;
-pub use state::{PowerState, SetState, SourceInputState};
+use state::{PowerState, SetState, SourceInputState, State};
 use std::{fmt, io::Write};
 pub use stream::create_tcp_stream;
 use stream::ConnectionStream;
@@ -388,7 +387,7 @@ mod test {
 
         let s = create_tcp_stream("localhost", local_port)?;
         let mlogger = Box::new(MockLogger::new());
-        main2(args, s, mlogger).unwrap();
+        assert!(main2(args, s, mlogger).is_ok());
 
         let (to_receiver, query_data) = acceptor.join().unwrap()?;
         assert!(query_data.contains(&format!("{}?", State::Power)));

--- a/denon-control/src/lib.rs
+++ b/denon-control/src/lib.rs
@@ -345,7 +345,7 @@ mod test {
         let receiver_address = String::from("blub_receiver");
         assert_eq!(
             (receiver_address, 666),
-            get_receiver_and_port(&args, || Ok(String::from("some_receiver")))?
+            get_receiver_and_port(&args, || panic!())?
         );
         Ok(())
     }

--- a/denon-control/src/lib.rs
+++ b/denon-control/src/lib.rs
@@ -13,14 +13,14 @@ mod stream;
 #[cfg(test)]
 mod logger;
 
-use denon_connection::{DenonConnection, State};
-use state::{PowerState, SetState, SourceInputState};
-
+use denon_connection::DenonConnection;
+pub use denon_connection::{read, write_state};
 use getopts::Options;
+pub use state::State;
+pub use state::{PowerState, SetState, SourceInputState};
 use std::{fmt, io::Write};
-use stream::ConnectionStream;
-
 pub use stream::create_tcp_stream;
+use stream::ConnectionStream;
 
 // status object shall get the current status of the avr 1912
 // easiest way would be a map<Key, Value> where Value is an enum of u32 and String

--- a/denon-control/src/logger.rs
+++ b/denon-control/src/logger.rs
@@ -1,0 +1,8 @@
+use std::io::{self, Write};
+
+use mockall::mock;
+
+mock! {pub Logger {} impl Write for Logger {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize>;
+    fn flush(&mut self) -> io::Result<()>;
+}}

--- a/denon-control/src/main.rs
+++ b/denon-control/src/main.rs
@@ -365,7 +365,6 @@ mod test {
         let args = parse_args(string_args.into_iter().map(|a| a.to_string()).collect());
 
         let acceptor = thread::spawn(move || -> Result<Vec<String>, io::Error> {
-            // TODO no extra thread is needed for accept()
             let mut to_receiver = listen_socket.accept()?.0;
 
             write_state(&mut to_receiver, SetState::Power(PowerState::On))?;
@@ -397,15 +396,8 @@ mod test {
         let string_args = vec!["blub", "-a", "localhost"];
         let args = parse_args(string_args.into_iter().map(|a| a.to_string()).collect());
 
-        let acceptor = thread::spawn(move || -> Result<(), io::Error> {
-            // TODO no extra thread is needed for accept()
-            listen_socket.accept()?;
-            Ok(())
-        });
-
         main2(args, String::from("localhost"), local_port).unwrap();
 
-        acceptor.join().unwrap()?;
         Ok(())
     }
 

--- a/denon-control/src/main.rs
+++ b/denon-control/src/main.rs
@@ -130,7 +130,7 @@ impl std::convert::From<std::io::Error> for Error {
 
 fn main2(args: getopts::Matches, denon_name: String, denon_port: u16) -> Result<(), Error> {
     let s = create_tcp_stream(denon_name, denon_port)?;
-    let mut dc = DenonConnection::new(s)?;
+    let mut dc = DenonConnection::new(s, Box::new(std::io::stdout()))?;
 
     if args.opt_present("s") {
         println!("{}", print_status(&mut dc)?);

--- a/denon-control/src/stream.rs
+++ b/denon-control/src/stream.rs
@@ -22,17 +22,17 @@ impl ReadStream for TcpStream {
     }
 }
 
-pub trait ShutdownStream: Write {
+pub trait ConnectionStream: Write {
     fn shutdownly(&self) -> io::Result<()>;
-    fn try_clonely(&self) -> io::Result<Box<dyn ReadStream>>;
+    fn get_readstream(&self) -> io::Result<Box<dyn ReadStream>>;
 }
 
-impl ShutdownStream for TcpStream {
+impl ConnectionStream for TcpStream {
     fn shutdownly(&self) -> io::Result<()> {
         self.shutdown(std::net::Shutdown::Both)
     }
 
-    fn try_clonely(&self) -> io::Result<Box<dyn ReadStream>> {
+    fn get_readstream(&self) -> io::Result<Box<dyn ReadStream>> {
         Ok(Box::new(self.try_clone()?))
     }
 }
@@ -44,16 +44,16 @@ mock! {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize>;
         fn flush(&mut self) -> io::Result<()>;
     }
-    impl ShutdownStream for ShutdownStream {
+    impl ConnectionStream for ShutdownStream {
         fn shutdownly(&self) -> io::Result<()>;
-        fn try_clonely(&self) -> io::Result<Box<dyn ReadStream>>;
+        fn get_readstream(&self) -> io::Result<Box<dyn ReadStream>>;
     }
 }
 
 pub fn create_tcp_stream(
     denon_name: String,
     denon_port: u16,
-) -> Result<Box<dyn ShutdownStream>, io::Error> {
+) -> Result<Box<dyn ConnectionStream>, io::Error> {
     let s = TcpStream::connect((denon_name.as_str(), denon_port))?;
     s.set_read_timeout(None)?;
     s.set_nonblocking(false)?;

--- a/denon-control/src/stream.rs
+++ b/denon-control/src/stream.rs
@@ -51,10 +51,10 @@ mock! {
 }
 
 pub fn create_tcp_stream(
-    denon_name: String,
+    denon_name: &str,
     denon_port: u16,
 ) -> Result<Box<dyn ConnectionStream>, io::Error> {
-    let s = TcpStream::connect((denon_name.as_str(), denon_port))?;
+    let s = TcpStream::connect((denon_name, denon_port))?;
     s.set_read_timeout(None)?;
     s.set_nonblocking(false)?;
     Ok(Box::new(s))
@@ -70,13 +70,13 @@ mod test {
     fn connects_to_server() -> Result<(), io::Error> {
         let listener = TcpListener::bind("localhost:0")?;
         let addr = listener.local_addr()?;
-        assert!(create_tcp_stream(addr.ip().to_string(), addr.port()).is_ok());
+        assert!(create_tcp_stream(addr.ip().to_string().as_str(), addr.port()).is_ok());
         Ok(())
     }
 
     #[test]
     fn fails_to_connect_and_returns_unknown() {
-        let dc = create_tcp_stream(String::from("value"), 0);
+        let dc = create_tcp_stream("value", 0);
         assert!(matches!(dc, Err(_)));
     }
 }

--- a/denon-control/src/stream.rs
+++ b/denon-control/src/stream.rs
@@ -1,0 +1,76 @@
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+
+#[cfg(test)]
+use mockall::{automock, predicate::*};
+
+#[cfg_attr(test, automock)]
+pub trait ReadStream {
+    fn peekly(&self, buf: &mut [u8]) -> io::Result<usize>;
+    fn read_exactly(&self, buf: &mut [u8]) -> io::Result<()>;
+}
+
+impl ReadStream for TcpStream {
+    fn peekly(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.peek(buf)
+    }
+
+    fn read_exactly(&self, buf: &mut [u8]) -> io::Result<()> {
+        // why does this work?
+        let mut mself = self;
+        mself.read_exact(buf)
+    }
+}
+
+#[cfg_attr(test, automock)]
+pub trait ShutdownStream {
+    fn shutdownly(&self) -> io::Result<()>;
+    // TODO returning TcpStream breaks a bit the abstraction
+    fn try_clonely(&self) -> io::Result<TcpStream>;
+}
+
+impl ShutdownStream for TcpStream {
+    fn shutdownly(&self) -> io::Result<()> {
+        self.shutdown(std::net::Shutdown::Both)
+    }
+
+    fn try_clonely(&self) -> io::Result<TcpStream> {
+        self.try_clone()
+    }
+}
+
+pub trait WriteShutdownStream: Write + ShutdownStream {}
+
+impl WriteShutdownStream for TcpStream {}
+
+pub fn create_tcp_stream(
+    denon_name: String,
+    denon_port: u16,
+) -> Result<Box<dyn WriteShutdownStream>, io::Error> {
+    let s = TcpStream::connect((denon_name.as_str(), denon_port))?;
+    s.set_read_timeout(None)?;
+    s.set_nonblocking(false)?;
+    Ok(Box::new(s))
+}
+
+#[cfg(test)]
+mod test {
+    use std::{io, net::TcpListener};
+
+    use crate::stream::create_tcp_stream;
+
+    #[test]
+    fn connects_to_server() -> Result<(), io::Error> {
+        let listener = TcpListener::bind("localhost:0")?;
+        let addr = listener.local_addr()?;
+        assert!(create_tcp_stream(addr.ip().to_string(), addr.port()).is_ok());
+        let _ = listener.accept();
+        Ok(())
+    }
+
+    #[test]
+    fn fails_to_connect_and_returns_unknown() {
+        let dc = create_tcp_stream(String::from("value"), 0);
+        assert!(matches!(dc, Err(_)));
+    }
+}

--- a/denon-control/src/stream.rs
+++ b/denon-control/src/stream.rs
@@ -64,7 +64,6 @@ mod test {
         let listener = TcpListener::bind("localhost:0")?;
         let addr = listener.local_addr()?;
         assert!(create_tcp_stream(addr.ip().to_string(), addr.port()).is_ok());
-        let _ = listener.accept();
         Ok(())
     }
 

--- a/denon-control/tests/denon-control.rs
+++ b/denon-control/tests/denon-control.rs
@@ -1,6 +1,6 @@
 use assert_cmd::prelude::*; // Add methods on commands
 use predicates::prelude::*; // Used for writing assertions
-use std::{io, net::TcpListener, process::Command, thread}; // Run programs
+use std::{net::TcpListener, process::Command}; // Run programs
 
 #[test]
 fn denon_control_prints_help() -> Result<(), Box<dyn std::error::Error>> {
@@ -30,11 +30,6 @@ fn denon_control_connects_to_test_receiver() -> Result<(), Box<dyn std::error::E
     let listen_socket = TcpListener::bind("localhost:0")?;
     let local_port = listen_socket.local_addr()?.port();
 
-    let acceptor = thread::spawn(move || -> Result<(), io::Error> {
-        listen_socket.accept()?;
-        Ok(())
-    });
-
     let mut cmd = Command::cargo_bin("denon-control")?;
     cmd.arg("--address")
         .arg(format!("localhost:{}", local_port));
@@ -42,6 +37,5 @@ fn denon_control_connects_to_test_receiver() -> Result<(), Box<dyn std::error::E
         .success()
         .stdout(predicate::str::contains("using receiver: localhost"));
 
-    acceptor.join().unwrap()?;
     Ok(())
 }

--- a/denon-control/tests/denon-control.rs
+++ b/denon-control/tests/denon-control.rs
@@ -1,0 +1,28 @@
+use assert_cmd::prelude::*; // Add methods on commands
+use predicates::prelude::*; // Used for writing assertions
+use std::process::Command; // Run programs
+
+#[test]
+fn denon_control_prints_help() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("denon-control")?;
+
+    cmd.arg("--help");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Usage"));
+
+    Ok(())
+}
+
+#[test]
+fn denon_control_fails_to_connect() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("denon-control")?;
+
+    cmd.arg("--address").arg("localhost");
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("using receiver: localhost"))
+        .stderr(predicate::str::contains("Connection refused"));
+
+    Ok(())
+}

--- a/denon-control/tests/denon-control.rs
+++ b/denon-control/tests/denon-control.rs
@@ -1,11 +1,10 @@
 use assert_cmd::prelude::*; // Add methods on commands
 use predicates::prelude::*; // Used for writing assertions
-use std::process::Command; // Run programs
+use std::{io, net::TcpListener, process::Command, thread}; // Run programs
 
 #[test]
 fn denon_control_prints_help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("denon-control")?;
-
     cmd.arg("--help");
     cmd.assert()
         .success()
@@ -17,12 +16,32 @@ fn denon_control_prints_help() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn denon_control_fails_to_connect() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("denon-control")?;
-
     cmd.arg("--address").arg("localhost");
     cmd.assert()
         .failure()
         .stdout(predicate::str::contains("using receiver: localhost"))
         .stderr(predicate::str::contains("Connection refused"));
 
+    Ok(())
+}
+
+#[test]
+fn denon_control_connects_to_test_receiver() -> Result<(), Box<dyn std::error::Error>> {
+    let listen_socket = TcpListener::bind("localhost:0")?;
+    let local_port = listen_socket.local_addr()?.port();
+
+    let acceptor = thread::spawn(move || -> Result<(), io::Error> {
+        listen_socket.accept()?;
+        Ok(())
+    });
+
+    let mut cmd = Command::cargo_bin("denon-control")?;
+    cmd.arg("--address")
+        .arg(format!("localhost:{}", local_port));
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("using receiver: localhost"));
+
+    acceptor.join().unwrap()?;
     Ok(())
 }

--- a/denon-control/tests/denon-control.rs
+++ b/denon-control/tests/denon-control.rs
@@ -55,8 +55,7 @@ fn denon_control_queries_receiver_state() -> Result<(), Box<dyn std::error::Erro
 
     let acceptor = thread::spawn(move || -> Result<(TcpStream, Vec<String>), io::Error> {
         let mut to_receiver = listen_socket.accept()?.0;
-        let mut received_data = Vec::new();
-        received_data.append(&mut read(&mut to_receiver, 1)?);
+        let mut received_data = read(&mut to_receiver, 1)?;
         write_state(&mut to_receiver, SetState::Power(PowerState::On))?;
         received_data.append(&mut read(&mut to_receiver, 1)?);
         write_state(

--- a/denon-control/tests/denon-control.rs
+++ b/denon-control/tests/denon-control.rs
@@ -1,6 +1,13 @@
 use assert_cmd::prelude::*; // Add methods on commands
+use denon_control::{read, write_state, PowerState, SetState, SourceInputState, State};
 use predicates::prelude::*; // Used for writing assertions
-use std::{net::TcpListener, process::Command}; // Run programs
+use predicates::str::contains;
+use std::{
+    io,
+    net::{TcpListener, TcpStream},
+    process::Command,
+    thread,
+}; // Run programs
 
 #[test]
 fn denon_control_prints_help() -> Result<(), Box<dyn std::error::Error>> {
@@ -19,7 +26,7 @@ fn denon_control_fails_to_connect() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--address").arg("localhost");
     cmd.assert()
         .failure()
-        .stdout(predicate::str::contains("using receiver: localhost"))
+        .stdout(predicate::str::contains("using receiver: localhost:"))
         .stderr(predicate::str::contains("Connection refused"));
 
     Ok(())
@@ -35,7 +42,85 @@ fn denon_control_connects_to_test_receiver() -> Result<(), Box<dyn std::error::E
         .arg(format!("localhost:{}", local_port));
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("using receiver: localhost"));
+        .stdout(contains("using receiver: localhost:"));
+
+    Ok(())
+}
+
+#[test]
+fn denon_control_queries_receiver_state() -> Result<(), Box<dyn std::error::Error>> {
+    let listen_socket = TcpListener::bind("localhost:0")?;
+    let local_port = listen_socket.local_addr()?.port();
+    let mut cmd = Command::cargo_bin("denon-control")?;
+
+    let acceptor = thread::spawn(move || -> Result<(TcpStream, Vec<String>), io::Error> {
+        let mut to_receiver = listen_socket.accept()?.0;
+
+        let received_data = Vec::new();
+
+        // while received_data.len() < 4 {
+        //     println!("received data size {}", received_data.len());
+        //     let mut tmp_data = read(&mut to_receiver, 10)?;
+        //     received_data.append(&mut tmp_data);
+        // }
+
+        write_state(&mut to_receiver, SetState::Power(PowerState::On))?;
+        write_state(
+            &mut to_receiver,
+            SetState::SourceInput(SourceInputState::Dvd),
+        )?;
+        write_state(&mut to_receiver, SetState::MainVolume(230))?;
+        write_state(&mut to_receiver, SetState::MaxVolume(666))?;
+
+        Ok((to_receiver, received_data))
+    });
+
+    let expected = "Current status of receiver:\n\tPower(ON)\n\tSourceInput(DVD)\n\tMainVolume(230)\n\tMaxVolume(666)\n";
+
+    cmd.arg("--address")
+        .arg(format!("localhost:{}", local_port))
+        .arg("--status");
+    cmd.assert().success().stdout(contains(expected));
+
+    let (_to_receiver, received_data) = acceptor.join().unwrap()?;
+
+    println!("{:?}", received_data);
+
+    //    assert!(received_data.contains(&format!("{}?", State::Power)));
+    //    assert!(received_data.contains(&format!("{}?", State::MaxVolume)));
+
+    Ok(())
+}
+
+#[test]
+fn denon_control_sets_receiver_state() -> Result<(), Box<dyn std::error::Error>> {
+    let listen_socket = TcpListener::bind("localhost:0")?;
+    let local_port = listen_socket.local_addr()?.port();
+    let mut cmd = Command::cargo_bin("denon-control")?;
+
+    let acceptor = thread::spawn(move || -> Result<TcpStream, io::Error> {
+        let to_receiver = listen_socket.accept()?.0;
+        Ok(to_receiver)
+    });
+
+    cmd.arg("--address")
+        .arg(format!("localhost:{}", local_port))
+        .arg("--power")
+        .arg("STANDBY")
+        .arg("--input")
+        .arg("CD")
+        .arg("--volume")
+        .arg("127");
+    cmd.assert()
+        .success()
+        .stdout(contains("using receiver: localhost:"));
+
+    let mut to_receiver = acceptor.join().unwrap()?;
+    let received_data = read(&mut to_receiver, 10)?;
+
+    assert!(received_data.contains(&format!("{}", SetState::SourceInput(SourceInputState::Cd))));
+    assert!(received_data.contains(&format!("{}", SetState::MainVolume(50))));
+    assert!(received_data.contains(&format!("{}", SetState::Power(PowerState::Standby))));
 
     Ok(())
 }


### PR DESCRIPTION
Get testing on a better level with software tests. These can be used if denon-control actually works according to the specification at the public API level.

Traits and mocks allow to cover more branches with more explicit test expectations. Also tests should be more stable with less system functions used.