### PR TITLE
Play with macro which prevents circles in mutex dependencies

### DIFF
--- a/type_state/src/lock_order.rs
+++ b/type_state/src/lock_order.rs
@@ -68,16 +68,21 @@ mod test {
     }
 
     // from https://cs.opensource.google/fuchsia/fuchsia/+/main:src/connectivity/network/netstack3/core/lock-order/src/relation.rs;l=107;drc=e2e00bc897e7362f33b25a7d98d9d7ba5ff07f69
+    // forward in graph
     pub trait LockAfterF<A> {}
 
+    // backward in graph
     pub trait LockBefore<X> {}
 
+    // automatic backward implementation
     impl<B: LockAfterF<A>, A> LockBefore<B> for A {}
 
+    // creates a graph with edges von A to B and all predecessors of A to B
     #[macro_export]
     macro_rules! impl_lock_after {
         ($A:ty => $B:ty) => {
             impl LockAfterF<$A> for $B {}
+            // in case of circular dependency this will create a second trait LockAfterF<$A> implementation and cause compile error
             impl<X: LockBefore<$A>> LockAfterF<X> for $B {}
         };
     }

--- a/type_state/src/lock_order.rs
+++ b/type_state/src/lock_order.rs
@@ -85,11 +85,14 @@ mod test {
     enum A {}
     enum B {}
     enum C {}
+    enum D {}
 
     #[test]
     fn impl_lock_after_test() {
         impl_lock_after!(A => B);
+        // impl_lock_after!(B => A);
         impl_lock_after!(B => C);
-        // impl_lock_after!(C => A); // this will create a compile error
+        impl_lock_after!(C => D);
+        // impl_lock_after!(D => A); // this will create a compile error
     }
 }


### PR DESCRIPTION
If there is a circle a deadlock might happen. When it is impossible to create circles deadlocks are impossible via mutexes as well.